### PR TITLE
add workshop-app link & remove unused headers

### DIFF
--- a/source/contrWkshpFeb23.rst
+++ b/source/contrWkshpFeb23.rst
@@ -8,25 +8,15 @@ Contributing to PsychoPy/JS (1 day, virtual)
   About 
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  This workshop is designed to give a hands-on introduction to PsychoPy/JS users of any background on how to contribute to the open-source project. It is suitable for almost anyone involved with PsychoPy or Pavlovia, ranging from those who simply want to contribute to documentation using reStructuredText, to those who what to resolve issues or fix bugs in Python or JavaScript. 
+  This workshop is designed to give a hands-on introduction to PsychoPy/JS users of any background on how to contribute to the open-source project. It is suitable for almost anyone involved with PsychoPy or Pavlovia, ranging from those who simply want to contribute to documentation using reStructuredText, to those who what to resolve issues or fix bugs in Python or JavaScript.
+
+  This event schedules on 17 February 2023 **booked up completely** within a couple of hours after an announcement on the user forum. Apologies. We had not anticipated the level of interest. 
   
+  Please `apply here for future contributor workshops <https://run.pavlovia.org/pavlovia/survey/?surveyId=8683bac0-34d1-4505-b3dc-669d69536917>`_.
+    
   .. image:: /_images/contribWkshpFeb23Ad.jpg
     :align: center
 
-  Draft timetable
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  Coming soon.
-
-  What can I do to prepare?
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  
-  Coming soon.
-  
-  Materials
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  Coming soon.
 
   Accessibility
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This updates the contributor-workshop page by adding a link to the new application in Surveys, and deleting some headers that were never filled in.