### PR TITLE
add minor updates to translator workshop slides after East Asia workshop

### DIFF
--- a/source/translators/index.rst
+++ b/source/translators/index.rst
@@ -118,17 +118,12 @@ thorough proficiency in at least three things, requiring months or years of stud
 
   <a href="https://desktop.github.com/" target="_blank">GitHub Desktop</a>
 
-Quick overview of steps
---------------------------------
-
-- preliminaries
-- setting up the *git* / *GitHub* workflow
-- working on translations and making associated pull requests
 
 Today
 -----------------------------------
 
-We're going to work through these one by one, along with a couple of extra topics, if there's time
+- We're going to work through the first two of these, where we will make pull requests at the same time we do translations
+- Therefore, steps 3-5 are optional topics or elaborations
 
 .. toctree::
     :maxdepth: 1

--- a/source/translators/makePullRequest.rst
+++ b/source/translators/makePullRequest.rst
@@ -114,8 +114,6 @@ Why the prefix?
 
 - For example:
 
-  - ``DOCS: Update mappings.txt for Thai``
-
   - ``DOCS: Add translations to Portuguese in Brazil``
 
   - ``DOCS: Add start-up tips to Modern Standard Arabic`` 
@@ -333,13 +331,5 @@ Yes
 - From *GitHub Desktop*
   
   - ``Repository > Pull``
-
-Or the faster way in *GitHub Desktop*
-
-- ``Branch > Update from Upstream
-
-FINISHED!!
-
-The rest is optional. It might help you with some concepts though.
  
 On to :ref:`other things to consider`

--- a/source/translators/setUpVersionControl.rst
+++ b/source/translators/setUpVersionControl.rst
@@ -344,19 +344,18 @@ Step 5: Continual *Git* workflow
 
   - The reason is that other translators on your team may have changed things since you last did, making your copy out of date
 
-Alternative: *pull* then *push*
----------------------------------
+AVOID FOR NOW: *pull* then *push*
+-----------------------------------
 
-There is an alternative to the *sync-pull* approach
+- If you happen to be tempted to do so, avoid the  trick below for now in *GitHub Desktop*. 
+- Currently, this particular software is selecting the *dev* branch as a default
 
-- *pull* from *upstream*, then *push* to *origin*
+  - ... and there doesn't seem to be a way make it refer to the *release* branch 
+- This means that the command below would merge the upstream *dev* branch into your local *release* branch
 
-- ``Branch > Update from upstream/master``
-  
-  - (It might tell you that it's already up to date) 
-- ``Repository > Push`` (if there were changes from *upstream*)
+  - ... which would be disastrous
 
-**NOTE**: This is faster, but I tend to avoid it because my understanding of *Git* is limited, and this allows me to keep things simple.
+``Branch > Update from upstream/master``
 
 Step 6: Continual *Git* workflow
 -----------------------------------

--- a/source/translators/workOnTranslations.rst
+++ b/source/translators/workOnTranslations.rst
@@ -43,7 +43,7 @@ Screenshot of localization files in |PsychoPy|
 
 ``ll_`` (language), follwed by ``_CC`` (country), for example:
 
-- |zh_CN| for Chinese in the PRC (simplified)\*
+- |zh_CN| for Chinese in the PRC (simplified)
 - |zh_TW| for Chinese in the ROC (complex)
 - |ko_KR| for Korean in South Korea
 - |th_TH| for Thai in Thailand
@@ -407,7 +407,8 @@ Step 3: Translating in *Poedit*
   - Go to: ``Additional keywords``
 - The following keyword should be in that box (with the preceding underscore): 
  
-  - ``_translate`` 
+``_translate`` 
+
 - If it **isn't**, type it in  
 - Save your work (``File > Save``)
 
@@ -524,7 +525,7 @@ Note A: Leave certain technical terms alone
 - These are usually indicated with an uppercase first letter
 - Check the Japanese localization (``ja_JP/LC_MESSAGES/messages.po``) if in doubt
 
-  - The Simplified Chinese ``.po`` file also has some examples of this already
+  - The Simplified Chinese ``.po`` file also has some examples
 
 Note B: Formatting arguments
 --------------------------------------------
@@ -540,7 +541,7 @@ If there are formatting arguments in the original string (``%s``, ``%(first)i``)
 
   - (and/or Simplified Chinese, if you are in that language)
 
-\* As you already know, word order changes across languages. Therefore, the placement of these formatting arguments within the translated string may differ from the US-English string. 
+\* Word order changes across languages, of course. So the placement of these formatting arguments within the translated string may differ from the US-English string. 
 
 Note C1: Using the Japanese ``.po`` file for guidance
 -------------------------------------------------------
@@ -697,14 +698,13 @@ There are two files this time
 **IMPORTANT**: Again, be sure to **UN**-check the ``.mo`` file if it is checked.
 
 4d2: Commit changes
-------------------------------------
+----------------------
 
 - Commit these changes
 
   - add the following message to the box underneath with the temporary text *Summary (required)*
 
-    - ``DOCS: Add some startup tips to Turkish`` (for example)
-    - ``DOCS: Add some startup tips to Spanish in Mexico`` (another example)
+    - ``DOCS: Add some startup tips to Spanish in Mexico`` (for example)
     
       -(must be 50 characters or fewer; add extra information under ``Description``, if necessary) 
     - (ignore the box labeled ``Description`` for now)


### PR DESCRIPTION
@peircej Mostly tweaks and typos. But I did change the slide about pulling from upstream. It's now in there as something to avoid entirely in GitHub Desktop, at least until we can find a way to prevent it from merging upstream _dev_ into local _release_.