### PR TITLE
Add transl-wkshp info to prevent certain mishaps

### DIFF
--- a/source/translators/setUpVersionControl.rst
+++ b/source/translators/setUpVersionControl.rst
@@ -65,7 +65,7 @@ Step 1: Get *Git* and *GitHub* working
 - *Git* is free software for your computer
 - *GitHub* is an free online system, which you need to sign up for
 
-Step 1a: Install *Git*
+1a: Install *Git*
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - download *Git* |downloadGitHere| 
@@ -85,7 +85,7 @@ Step 1a: Install *Git*
 
   <a href="https://youtu.be/F02LEVYEmQw" target="_blank">YouTube video</a>
 
-Step 1b: Sign up for *GitHub*
+1b: Sign up for *GitHub*
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Go to |signUpForGithubHere|
@@ -115,7 +115,7 @@ Step 2: *Fork* the *psychopy* repository
 
 **NOTE**: Technically and more generally, it's copying a repository, while also disconnecting it from other previous committers
 
-Step 2a: Find the *psychopy/psychopy* repository
+2a: Find the *psychopy/psychopy* repository
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - While logged in to *GitHub*
@@ -134,7 +134,7 @@ Step 2a: Find the *psychopy/psychopy* repository
 
 ..
 
-Step 2b: *Fork* the *psychopy/psychopy* repository
+2b: *Fork* the *psychopy/psychopy* repository
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Find the ``Fork`` pull-down menu located near the upper right corner
@@ -147,9 +147,30 @@ Step 2b: *Fork* the *psychopy/psychopy* repository
 ..
 
 - Choose the following: ``+ Create a new fork``
-- **IMPORTANT**: Be sure to **UN**-Check the box labeled as follows: ``Copy the ____ branch only``
 
-  - In other words, please copy **all** the branches 
+  - For convenience, be sure to **UN**-Check the box labeled as follows: ``Copy the dev branch only``
+  
+    - In other words, please copy **all** the branches 
+  - If you only get the *dev* branch, you won't be able to contribute to the *release* branch
+  
+    - So you'd need to add it (see next slide) 
+
+2c: How to add an upstream branch to your fork
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- If you didn't check that box, and only forked the *dev* branch, you'll need to add the *release* branch 
+- Go to your fork of the repo
+
+  - Go to the branch pull-down menu at the upper-left, which should say *dev*
+  - In the pull-down menu, choose ``View all branches`` (at the bottom)
+  - On the next screen, click the box labeled ``New branch`` at the upper right
+  
+    - Under ``New branch name`` type in *release*
+    - Under ``Source``
+    
+      - choose ``psychopy/psychopy`` in the upper pull-down menu
+      - choose ``release`` in the lower pull-down menu
+  Click ``Create new branch``
 
 What is a *fork*?
 ^^^^^^^^^^^^^^^^^^^^
@@ -225,7 +246,7 @@ What if I use *Linux*?
   <a href="https://github.com/shiftkey/desktop" target="_blank">the shiftkey/desktop fork</a>
 
 
-Step 3a: Download and install *GitHub Desktop*
+3a: Download and install *GitHub Desktop*
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Go to the homepage for |homepageForGithubDesktop|
@@ -246,7 +267,7 @@ Step 4: Cloning
   - Unlike *forking* it doesn't disassociate anyone
 - It also establishes a connection between your local and online files 
 
-Step 4a: How to start cloning from *GitHub Desktop*
+4a: How to start cloning from *GitHub Desktop*
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - create an empty folder in a logical place (i.e., not on your desktop) on your computer (e.g., under ``Documents``)
@@ -262,7 +283,7 @@ Step 4a: How to start cloning from *GitHub Desktop*
     - choose *psychopy* 
   - (In *GitFiend*, you don't sign in. You just provide the repository URL, which can be found in the *GitHub* repository under the ``<> Code`` button, where you then choose the ``Local`` tab, then the ``https`` link)
 
-Step 4b: How to finish cloning
+4b: How to finish cloning
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   
 - *psychopy* should be listed because it's already forked in your online account

--- a/source/translators/setUpVersionControl.rst
+++ b/source/translators/setUpVersionControl.rst
@@ -158,11 +158,11 @@ Step 2: *Fork* the *psychopy* repository
 2c: How to add an upstream branch to your fork
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- If you didn't check that box, and only forked the *dev* branch, you'll need to add the *release* branch 
 - Go to your fork of the repo
 
   - Go to the branch pull-down menu at the upper-left, which should say *dev*
-  - In the pull-down menu, choose ``View all branches`` (at the bottom)
+  
+    - Choose ``View all branches`` (at the bottom)
   - On the next screen, click the box labeled ``New branch`` at the upper right
   
     - Under ``New branch name`` type in *release*

--- a/source/translators/setUpVersionControl.rst
+++ b/source/translators/setUpVersionControl.rst
@@ -249,6 +249,9 @@ Step 4: Cloning
 Step 4a: How to start cloning from *GitHub Desktop*
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- create an empty folder in a logical place (i.e., not on your desktop) on your computer (e.g., under ``Documents``)
+
+  - You can call it ``psychopy`` if you wish 
 - in *GitHub Desktop* on a Mac
 
   - ``GitHub Desktop > Settings > Accounts``
@@ -264,9 +267,9 @@ Step 4b: How to finish cloning
   
 - *psychopy* should be listed because it's already forked in your online account
  
-  - under ``Local Path`` at the bottom, choose a **logical** place on your computer for the cloned repository (e.g., not your desktop)
+  - under ``Local Path`` at the bottom, choose the empty folder that you just created
   
-    - click ``Clone``
+  - click ``Clone``
     - This might take a minute, depending on your connection speed
 
 The result of cloning

--- a/source/translators/workOnTranslations.rst
+++ b/source/translators/workOnTranslations.rst
@@ -766,6 +766,19 @@ Step 4: Translating the *Start-up Tips*
    * - ``tips.txt``
      - ``tips_ja_JP.txt``
 
+Note on humor in *Start-up tips*
+--------------------------------------
+
+- Some of the humor in the *Start-up tips* might not translate well
+- Feel free to delete humor that would be too odd
+
+  - or replace them with mild humor that would be more appropriate
+- Humor must be respectful and suitable for using in a classroom, laboratory, or other professional situation
+- Don't get too creative here
+- If you have any doubt, it is better to leave it out
+- It goes without saying that you should avoid any religious, political, disrespectful, or sexist material
+
+
 4d: Make a pull request for ``.po`` and ``.txt`` files
 --------------------------------------------------------
 
@@ -816,18 +829,6 @@ There are two files this time
   - Make sure it says *Able to merge* in the box at the top
   - Leave a comment only if you think it's necessary (it shouldn't be for translations)
   - Click ``Create pull request``
-
-Note on humor in *Start-up tips*
---------------------------------------
-
-- Some of the humor in the *Start-up tips* might not translate well
-- Feel free to delete humor that would be too odd
-
-  - or replace them with mild humor that would be more appropriate
-- Humor must be respectful and suitable for using in a classroom, laboratory, or other professional situation
-- Don't get too creative here
-- If you have any doubt, it is better to leave it out
-- It goes without saying that you should avoid any religious, political, disrespectful, or sexist material
 
 Done with translating
 ------------------------

--- a/source/translators/workOnTranslations.rst
+++ b/source/translators/workOnTranslations.rst
@@ -10,13 +10,13 @@ Overview
 -------------
 
 - (Step 0: Ensure you are on the ``release`` branch before you change anything)
-- Step 1: Identifying the appropriate 5-6 character ``ll_CC`` locale name for your translation
-- Step 2: Configuring the ``mappings.txt`` file with a text editor
-- Step 3: Working on main translations with *Poedit*
+- Step 1: Identify the appropriate 5-6 character ``ll_CC`` locale name for your translation
+- Step 2: Edit the ``mappings.txt`` file
+- Step 3: Work on main translations with *Poedit*
   
   - configure ``Poedit``
-  - generate and translate the "strings" in the ``messages.po`` file
-- Step 4: Translating "Start-up tips" in |PsychoPy| with a text editor
+  - generate and translate "strings" in the ``messages.po`` file
+- Step 4: Translate "Start-up tips" with a text editor
   
 **NOTE**: Steps 3 and 4 aren't sequential; they're different translation processes
 

--- a/source/translators/workOnTranslations.rst
+++ b/source/translators/workOnTranslations.rst
@@ -9,6 +9,7 @@ Working on translations
 Overview
 -------------
 
+- (Step 0: Ensure you are on the ``release`` branch before you change anything)
 - Step 1: Identifying the appropriate 5-6 character ``ll_CC`` locale name for your translation
 - Step 2: Configuring the ``mappings.txt`` file with a text editor
 - Step 3: Working on main translations with *Poedit*
@@ -18,6 +19,17 @@ Overview
 - Step 4: Translating "Start-up tips" in |PsychoPy| with a text editor
   
 **NOTE**: Steps 3 and 4 aren't sequential; they're different translation processes
+
+Step 0: Ensure you are on the ``release`` branch
+--------------------------------------------------
+
+- You might be on the ``dev`` branch by default
+- Change this before you do any work
+
+  -  In *GitHub Desktop*
+  
+    -  look for the ``Current Branch`` pull-down tab at the upper left 
+    -  choose ``release`` from wherever it appears in the pull-down menu
 
 Step 1: What is the ``ll_CC`` locale name for my language?
 --------------------------------------------------------------


### PR DESCRIPTION
I wasn't warning them to make sure they were on the release branch before doing any work, so some ended up making changes to the dev branch. I also didn't warn them to create a new empty folder to clone into. So some of them were trying to clone into non-empty folders.