### PR TITLE
Remove slide 2 and 3 from carousel

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -177,13 +177,6 @@
             <div class="carousel-slide">
                 <img src="_static/1.png" alt="Official PsychoPy workshops">
             </div>
-            <div class="carousel-slide">
-                <img src="_static/inpersonworkshop.png" alt="PsychoPy workshop April 1st - 3rd 2025">
-            </div>
-            <div class="carousel-slide">
-                <img src="_static/hardwareworkshop.png" alt="EEG and Eyetracking workshop April 4th 2025 - learn how to integrate your PsychoPy experiment with Tobii eyetrackers and Brain products EEG">
-            </div>
-            <!-- Add more slides as needed -->
         </div>
         <button class="carousel-prev" onclick="prevSlide()">❮</button>
         <button class="carousel-next" onclick="nextSlide()">❯</button>


### PR DESCRIPTION
these slides specifically advertised in person nottingham events - which have taken place and no longer need advertising.